### PR TITLE
It appears super already returns the string. No need to call join (which throws an exception)

### DIFF
--- a/citation.rb
+++ b/citation.rb
@@ -28,7 +28,7 @@ module Jekyll
 
     def render(context)
       # get the content of the {% bibtex %} block
-      content = super.join
+      content = super
       @config = context.registers[:site].config['citation'] || {}
       @config['citation_style'] ||= 'apa'
       @config['citation_locale'] ||= 'en'


### PR DESCRIPTION
Liquid Exception: undefined method `join' for #<String:0x000000026d5f68> in index.markdown
[...]/plugins/citation.rb:31:in`render'
